### PR TITLE
Update buildx.sh

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -54,7 +54,7 @@ function build {
     cp alfresco-share-base-distribution-*/amps/* target/amps
     sed -i '' 's/alfresco-base-tomcat:tomcat9-jre11-centos7.*/alfresco-base-tomcat:tomcat9-jre11-centos7-202209261711/g' Dockerfile
     docker buildx build . --load --platform linux/arm64 -t $REPOSITORY/alfresco-content-repository-community:$REPO_COM_VERSION
-    cd ../../..
+    cd ../../../..
   fi
 
   # Repository Enterprise


### PR DESCRIPTION
go up one extra level after building the community repo to get back to the project root (the enterprise repo code seems to already have this change)